### PR TITLE
Force API to load over HTTPS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 (function(window) {
 	var YouTubeIframeLoader = {
-		src: '//www.youtube.com/iframe_api',
+		src: 'https://www.youtube.com/iframe_api',
 		loading: false,
 		loaded: false,
 		listeners: [],


### PR DESCRIPTION
Fixes `window.postMessage` errors when API is loaded over plain HTTP.

See also https://github.com/eXon/videojs-youtube/issues/67

Just begun using this module for [react-youtube](https://github.com/compedit/react-youtube) and it works perfectly except interaction with the iframe is broken when used with plain HTTP.

[Forcing HTTPS shouldn't be a problem anymore](http://www.paulirish.com/2010/the-protocol-relative-url/), I hope this is cool!
