### PR TITLE
Method should always be async

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,13 @@
 		listeners: [],
 
 		load: function(callback) {
+			var _this = this;
 			this.listeners.push(callback);
 
 			if(this.loaded) {
-				this.done();
+				setTimeout(function() {
+					_this.done();
+				});
 				return;
 			}
 
@@ -19,7 +22,6 @@
 
 			this.loading = true;
 
-			var _this = this;
 			window.onYouTubeIframeAPIReady = function() {
 				_this.loaded = true;
 				_this.done();


### PR DESCRIPTION
Currently, `load` ends up sometimes calling the callback immediately and sometimes later. As @isaacs sums up in [his blog post about async apis](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony):

> If you have an API which takes a callback,
> and sometimes that callback is called immediately,
> and other times that callback is called at some point in the future,
> then you will render any code using this API impossible to reason about, and cause the release of Zalgo.

From what I can tell, this is the if statement that calls the callback immediately when the youtube iframe API has already been loaded. This shouldn't call the callback immediately. That way, the user can be assured that the code they wrote directly after the `.load` will always happen before the callback.
